### PR TITLE
Allow chip element to be overridden

### DIFF
--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -10,7 +10,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     outline: "none",
   },
   root: {
-    display: "flex",
+    display: "inline-flex",
     position: "relative",
     height: 36,
     width: "auto",
@@ -24,6 +24,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     borderRadius: theme.borderRadius * 2,
     appearance: "none",
     transition: "all 150ms ease-out",
+    textDecoration: "none",
     "&:hover, &:focus, &:active": {
       extend: "defaultActive",
     },
@@ -101,11 +102,13 @@ const Chip: React.FC<ChipProps> = ({
   disabled,
   label,
   onClick,
+  element,
+  href,
 }) => {
   const classes = useStyles({ color, disabled });
-
+  const Element: keyof JSX.IntrinsicElements = element ? element : "button";
   return (
-    <button
+    <Element
       disabled={disabled}
       className={classNames({
         [classes.root]: true,
@@ -117,9 +120,10 @@ const Chip: React.FC<ChipProps> = ({
       })}
       onClick={onClick}
       style={style}
+      href={href}
     >
       <span>{label}</span>
-    </button>
+    </Element>
   );
 };
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -7,7 +7,6 @@ import {
   ReactNode,
   SetStateAction,
   Dispatch,
-  ReactHTMLElement,
 } from "react";
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -7,6 +7,7 @@ import {
   ReactNode,
   SetStateAction,
   Dispatch,
+  ReactHTMLElement,
 } from "react";
 
 /**
@@ -384,10 +385,12 @@ export interface IconProps {
  */
 export interface ChipProps {
   disabled?: boolean;
-  onClick: (e: React.MouseEvent) => unknown;
+  onClick?: (e: React.MouseEvent) => unknown;
   color?: "default" | "primary" | "secondary";
   className?: string;
   style?: React.CSSProperties;
   isActive?: boolean;
   label: string;
+  element?: keyof JSX.IntrinsicElements;
+  href?: string;
 }

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -275,7 +275,9 @@ const App: React.FC = () => {
         <Chip
           color="primary"
           label="All Sports"
-          onClick={(e) => console.log(e)}
+          // onClick={(e) => console.log(e)}
+          href="http://google.com"
+          element="a"
           isActive
         />
       </div>


### PR DESCRIPTION
Allows `<Chip />` to be assigned an HTML element other then the default `button` - useful for using `<a href=""`