### PR TITLE
fix(core): Add react-router-dom as a peerDependency and mark as exter…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0"
   },
   "dependencies": {
     "@material-ui/core": "^4.11.3",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -42,5 +42,5 @@ export default {
       tsconfig: "./tsconfig.json",
     }),
   ],
-  external: ["react", "react-dom", "prop-types"],
+  external: ["react", "react-dom", "prop-types", "react-router-dom"],
 };


### PR DESCRIPTION
Add react-router-dom as a peerDependency and mark as external in rollup.

I was having an issue using the Button component because of an error react-router was throwing. 
`Error: Invariant failed: You should not use <Link> outside a <Router>`

The react-router-dom dependency is being bundled with the package and causing problems when installed because there end up being two versions.