### PR TITLE
fix(Fab): Fix color prop pass from Fab to Icon

### DIFF
--- a/packages/core/src/Fab/__snapshots__/Fab.test.tsx.snap
+++ b/packages/core/src/Fab/__snapshots__/Fab.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Renders without crashing, matches snapshot 1`] = `
             <path
               d="M22.627,14.87,15,22.5l-3.75.75L12,19.5l7.631-7.63a2.113,2.113,0,0,1,2.991,0l.009.008A2.116,2.116,0,0,1,22.627,14.87Z"
               fill="none"
-              stroke="#2C2933"
+              stroke="#9D9D9E"
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="1.5"
@@ -37,7 +37,7 @@ exports[`Renders without crashing, matches snapshot 1`] = `
             <path
               d="M8.246,20.25h-6a1.5,1.5,0,0,1-1.5-1.5V2.25a1.5,1.5,0,0,1,1.5-1.5h15a1.5,1.5,0,0,1,1.5,1.5V9"
               fill="none"
-              stroke="#2C2933"
+              stroke="#9D9D9E"
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="1.5"
@@ -45,7 +45,7 @@ exports[`Renders without crashing, matches snapshot 1`] = `
             <path
               d="M8.246 5.25L14.246 5.25"
               fill="none"
-              stroke="#2C2933"
+              stroke="#9D9D9E"
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="1.5"
@@ -53,7 +53,7 @@ exports[`Renders without crashing, matches snapshot 1`] = `
             <path
               d="M5.246 9.75L14.246 9.75"
               fill="none"
-              stroke="#2C2933"
+              stroke="#9D9D9E"
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="1.5"
@@ -61,7 +61,7 @@ exports[`Renders without crashing, matches snapshot 1`] = `
             <path
               d="M5.246 14.25L12.746 14.25"
               fill="none"
-              stroke="#2C2933"
+              stroke="#9D9D9E"
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="1.5"

--- a/packages/core/src/Fab/index.tsx
+++ b/packages/core/src/Fab/index.tsx
@@ -111,8 +111,8 @@ const Fab: React.FC<FabProps> = ({
         onMouseEnter={toggleHovered}
         onMouseLeave={toggleHovered}
       >
-        <Icon style={{ borderRadius: "50%" }}>
-          {React.createElement(IconName, { color: iconColor })}
+        <Icon style={{ borderRadius: "50%" }} color={iconColor}>
+          {React.createElement(IconName)}
         </Icon>
       </button>
     </div>


### PR DESCRIPTION
fixes #53 

Since the Fab component is summoning the Icon component, shifted the color prop to pass directly to the Icon component. It was getting overridden previously.