### PR TITLE
feat (StatusIcon): Add StatusIcon component to Core

### DIFF
--- a/packages/core/src/StatusIcon/StatusIcon.test.tsx
+++ b/packages/core/src/StatusIcon/StatusIcon.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import ThemeProvider from "../ThemeProvider";
+import StatusIcon from ".";
+
+test("Renders without crashing, matches snapshot", () => {
+  const { container } = render(
+    <ThemeProvider>
+      <StatusIcon status="pending" />
+    </ThemeProvider>
+  );
+  expect(container).toMatchSnapshot();
+});
+
+test("Style object is passed and rendered correctly", () => {
+  const { getByTestId } = render(
+    <ThemeProvider>
+      <StatusIcon status="pending" style={{ position: "absolute" }} />
+    </ThemeProvider>
+  );
+  expect(getByTestId("statusIcon").hasAttribute("style")).toBeTruthy();
+});
+
+test("ClassName is passed and rendered correctly", () => {
+  const testClass = "test-1-2-3";
+  const { getByTestId } = render(
+    <ThemeProvider>
+      <StatusIcon status="pending" className={testClass} />
+    </ThemeProvider>
+  );
+  //console.log({ getByTestId("statusIcon") });
+  expect(getByTestId("statusIcon").getAttribute("class")).toContain(
+    "test-1-2-3"
+  );
+});

--- a/packages/core/src/StatusIcon/StatusIcon.test.tsx
+++ b/packages/core/src/StatusIcon/StatusIcon.test.tsx
@@ -29,7 +29,6 @@ test("ClassName is passed and rendered correctly", () => {
       <StatusIcon status="pending" className={testClass} />
     </ThemeProvider>
   );
-  //console.log({ getByTestId("statusIcon") });
   expect(getByTestId("statusIcon").getAttribute("class")).toContain(
     "test-1-2-3"
   );

--- a/packages/core/src/StatusIcon/__snapshots__/StatusIcon.test.tsx.snap
+++ b/packages/core/src/StatusIcon/__snapshots__/StatusIcon.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders without crashing, matches snapshot 1`] = `
+<div>
+  <div
+    class="root-0-2-1 root-d0-0-2-2"
+    data-testid="statusIcon"
+  >
+    <svg
+      fill="none"
+      height="48"
+      viewBox="0 0 48 48"
+      width="48"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M21 1.73205C22.8564 0.660254 25.1436 0.660254 27 1.73205L41.7846 10.2679C43.641 11.3397 44.7846 13.3205 44.7846 15.4641V32.5359C44.7846 34.6795 43.641 36.6603 41.7846 37.7321L27 46.2679C25.1436 47.3397 22.8564 47.3397 21 46.2679L6.21539 37.7321C4.35899 36.6603 3.21539 34.6795 3.21539 32.5359V15.4641C3.21539 13.3205 4.35898 11.3397 6.21539 10.2679L21 1.73205Z"
+        fill="#7A60FF"
+        stroke="white"
+      />
+      <circle
+        cx="24"
+        cy="24"
+        fill="white"
+        r="13"
+      />
+      <path
+        clip-rule="evenodd"
+        d="M25.5388 16L25.1327 21.9933H30.4L22.8612 31.5L23.2673 25.5067H18L25.5388 16Z"
+        fill="#7A60FF"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/core/src/StatusIcon/icons/CorrectDiamond.tsx
+++ b/packages/core/src/StatusIcon/icons/CorrectDiamond.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { IconProps } from "../../types";
+
+const CorrectDiamond: React.FC<IconProps> = ({ className, color, style }) => {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={style}
+    >
+      <path
+        d="M21 1.732a6 6 0 016 0l14.7846 8.5359a6 6 0 013 5.1962v17.0718a6 6 0 01-3 5.1962L27 46.2679a6 6 0 01-6 0L6.2154 37.7321a6 6 0 01-3-5.1962V15.4641a6 6 0 013-5.1962L21 1.7321z"
+        fill={color}
+        stroke="#fff"
+      />
+      <circle cx="24" cy="24" r="13" fill="#fff" />
+      <path
+        d="M18 24.2857l3.9866 3.4286L30 20"
+        stroke={color}
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default CorrectDiamond;

--- a/packages/core/src/StatusIcon/icons/DisqualifiedDiamond.tsx
+++ b/packages/core/src/StatusIcon/icons/DisqualifiedDiamond.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { IconProps } from "../../types";
+
+const DisqualifiedDiamond: React.FC<IconProps> = ({
+  className,
+  color,
+  style,
+}) => {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={style}
+    >
+      <path
+        d="M21 1.73205C22.8564 0.660254 25.1436 0.660254 27 1.73205L41.7846 10.2679C43.641 11.3397 44.7846 13.3205 44.7846 15.4641V32.5359C44.7846 34.6795 43.641 36.6603 41.7846 37.7321L27 46.2679C25.1436 47.3397 22.8564 47.3397 21 46.2679L6.21539 37.7321C4.35899 36.6603 3.21539 34.6795 3.21539 32.5359V15.4641C3.21539 13.3205 4.35898 11.3397 6.21539 10.2679L21 1.73205Z"
+        fill={color}
+        stroke="white"
+      />
+      <circle cx="24" cy="24" r="13" fill="white" />
+      <path
+        d="M31.0711 24L16.9289 24"
+        stroke={color}
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default DisqualifiedDiamond;

--- a/packages/core/src/StatusIcon/icons/IncorrectDiamond.tsx
+++ b/packages/core/src/StatusIcon/icons/IncorrectDiamond.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { IconProps } from "../../types";
+
+const IncorrectDiamond: React.FC<IconProps> = ({ className, color, style }) => {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={style}
+    >
+      <path
+        d="M21 1.732a6 6 0 016 0l14.7846 8.5359a6 6 0 013 5.1962v17.0718a6 6 0 01-3 5.1962L27 46.2679a6 6 0 01-6 0L6.2154 37.7321a6 6 0 01-3-5.1962V15.4641a6 6 0 013-5.1962L21 1.7321z"
+        fill={color}
+        stroke="#fff"
+      />
+      <circle cx="24" cy="24" r="13" fill="#fff" />
+      <path
+        d="M19 29l10-10M29 29L19 19"
+        stroke={color}
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default IncorrectDiamond;

--- a/packages/core/src/StatusIcon/icons/LiveDiamond.tsx
+++ b/packages/core/src/StatusIcon/icons/LiveDiamond.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { IconProps } from "../../types";
+
+const LiveDiamond: React.FC<IconProps> = ({ className, color, style }) => {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={style}
+    >
+      <path
+        d="M21 1.73205C22.8564 0.660254 25.1436 0.660254 27 1.73205L41.7846 10.2679C43.641 11.3397 44.7846 13.3205 44.7846 15.4641V32.5359C44.7846 34.6795 43.641 36.6603 41.7846 37.7321L27 46.2679C25.1436 47.3397 22.8564 47.3397 21 46.2679L6.21539 37.7321C4.35899 36.6603 3.21539 34.6795 3.21539 32.5359V15.4641C3.21539 13.3205 4.35898 11.3397 6.21539 10.2679L21 1.73205Z"
+        fill={color}
+        stroke="white"
+      />
+      <circle cx="24" cy="24" r="13" fill="white" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M25.5388 16L25.1327 21.9933H30.4L22.8612 31.5L23.2673 25.5067H18L25.5388 16Z"
+        fill={color}
+      />
+    </svg>
+  );
+};
+
+export default LiveDiamond;

--- a/packages/core/src/StatusIcon/index.tsx
+++ b/packages/core/src/StatusIcon/index.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { defaultTheme as PickUpTheme } from "../ThemeProvider/defaultTheme";
+import { createUseStyles } from "react-jss";
+import CorrectDiamond from "./icons/CorrectDiamond";
+import IncorrectDiamond from "./icons/IncorrectDiamond";
+import DisqualifiedDiamond from "./icons/DisqualifiedDiamond";
+import LiveDiamond from "./icons/LiveDiamond";
+import classNames from "classnames";
+
+import { IconProps, StatusIconProps } from "../types";
+
+const useStyles = createUseStyles({
+  root: {
+    position: "relative",
+    width: (props) => props.size,
+    height: "auto",
+    "& > svg": {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "auto",
+    },
+  },
+});
+
+const colorMapper: { [status: string]: string } = {
+  graded_true: PickUpTheme.colors.green.base,
+  graded_false: PickUpTheme.colors.red.base,
+  disqualified: PickUpTheme.colors.grey.base,
+  closed: PickUpTheme.colors.grey.base,
+  pending: PickUpTheme.colors.primary.base,
+};
+
+const IconMapper: { [status: string]: React.FC<IconProps> } = {
+  graded_true: CorrectDiamond,
+  graded_false: IncorrectDiamond,
+  disqualified: DisqualifiedDiamond,
+  closed: DisqualifiedDiamond,
+  pending: LiveDiamond,
+};
+
+const StatusIcon: React.FC<StatusIconProps> = ({
+  status,
+  className,
+  size = 48,
+  style,
+}) => {
+  const classes = useStyles({ size });
+  const MappedIcon = IconMapper[status] || LiveDiamond;
+  return (
+    <div
+      data-testid="statusIcon"
+      className={classNames(classes.root, className)}
+      style={style}
+    >
+      <MappedIcon
+        color={colorMapper[status] || PickUpTheme.colors.primary.base}
+      />
+    </div>
+  );
+};
+
+export default StatusIcon;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ import Paper from "./Paper";
 import PickerButton from "./PickerButton";
 import ProgressButton from "./ProgressButton";
 import Select from "./Select";
+import StatusIcon from "./StatusIcon";
 import TextArea from "./TextArea";
 import TextInput from "./TextInput";
 import ThemeProvider from "./ThemeProvider";
@@ -46,6 +47,7 @@ export {
   PickerButton,
   ProgressButton,
   Select,
+  StatusIcon,
   TextArea,
   TextInput,
   ThemeProvider,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -267,6 +267,26 @@ export interface IconBaseProps {
   style?: React.CSSProperties;
 }
 
+/**
+ *
+ * StatusIcon Component
+ *
+ */
+
+export type PickStatus =
+  | "graded_true"
+  | "graded_false"
+  | "disqualified"
+  | "closed"
+  | "pending";
+
+export interface StatusIconProps {
+  status: PickStatus;
+  className?: string;
+  size?: number;
+  style?: React.CSSProperties;
+}
+
 export interface BaseFormikFields {
   id: string;
   name: string;

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -21,6 +21,7 @@ import {
   Paper,
   PickerButton,
   ProgressButton,
+  StatusIcon,
   Hero,
   Card,
   // HorizontalRule,
@@ -421,6 +422,9 @@ const App: React.FC = () => {
         <Icon>
           <Create />
         </Icon>
+      </div>
+      <div style={{ marginTop: 40, marginBottom: 40, padding: 40 }}>
+        <StatusIcon status={"pending"} />
       </div>
       <div style={{ marginTop: 40, marginBottom: 40, padding: 40 }}>
         <Fab

--- a/stories/StatusIcon.stories.tsx
+++ b/stories/StatusIcon.stories.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+
+import { StatusIcon, defaultTheme as PickUpTheme } from "@playpickup/core";
+import { StatusIconProps } from "@playpickup/core/src/types";
+
+export default {
+  title: "Core/StatusIcon",
+  component: StatusIcon,
+  argTypes: {
+    status: {
+      control: {
+        type: "select",
+        options: [
+          "graded_true",
+          "graded_false",
+          "disqualified",
+          "closed",
+          "pending (default)",
+        ],
+      },
+      defaultValue: "pending",
+      description:
+        "Status of the pick. Pending is default; closed and diesqualified render the same result",
+    },
+    color: {
+      control: "color",
+      defaultValue: PickUpTheme.colors.primary.base,
+      description: "Color of the icon",
+      table: {
+        category: "Styling",
+      },
+    },
+    className: {
+      defaultValue: "",
+      description: "Additional className to be applied to the icon container",
+      control: "text",
+      table: {
+        category: "Styling",
+      },
+    },
+
+    size: {
+      defaultValue: 48,
+      description: "Size of the icon, converts to pixels.",
+      control: "number",
+      table: {
+        category: "Styling",
+      },
+    },
+    style: {
+      defaultValue: null,
+      description: "Style object to apply to the icon container",
+      control: "object",
+      table: {
+        category: "Styling",
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<StatusIconProps> = (args) => <StatusIcon {...args} />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
Created a new StatusIcon component that takes one of the pick statuses (`graded_true, graded_false, disqualified, closed` or `pending`) and returns the correct icon with appropriate color.

Closes #156 