### PR TITLE
fix(themeProvider): Switch aggressive suffix to prefix

### DIFF
--- a/packages/core/src/ThemeProvider/specificityPlugin.ts
+++ b/packages/core/src/ThemeProvider/specificityPlugin.ts
@@ -16,9 +16,9 @@ import { SpecificityPluginProps, JssStyleSheet } from "../types";
 export function increaseSpecificity(options?: SpecificityPluginProps): Plugin {
   const selector = options?.selector ?? ":not(#\\20)";
   const repeat = options?.repeat ?? 3;
-  const suffix = Array(repeat + 1).join(selector);
+  const prefix = Array(repeat + 1).join(selector);
 
-  // 'rule' is left untyped because the Rule import from jss is not functioning as expected
+  // 'rule' is left untyped because the Rule import from jss is not recognizing all child properties
   function onProcessRule(rule, sheet: JssStyleSheet): Plugin["onProcessRule"] {
     const parent = rule.options.parent;
     if (
@@ -28,7 +28,7 @@ export function increaseSpecificity(options?: SpecificityPluginProps): Plugin {
     )
       return;
 
-    rule.selectorText += suffix;
+    rule.selectorText = prefix + rule.selectorText;
   }
   return { onProcessRule };
 }

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -200,7 +200,9 @@ const App: React.FC = () => {
           >
             👋 Howdy human!!!
           </Typography>
-          <Typography variant="title">title</Typography>
+          <Typography variant="title" className={classes.title}>
+            title
+          </Typography>
           <Typography variant="heading2">heading 2</Typography>
           <Typography variant="heading3">heading 3</Typography>
 

--- a/playground/src/App/makeMeUgly.css
+++ b/playground/src/App/makeMeUgly.css
@@ -4,3 +4,8 @@
 .Playground h1 {
   font-family: "Comic Sans", cursive;
 }
+
+.Playground h1::after {
+  content: "\263A";
+  color: red;
+}


### PR DESCRIPTION
By switching the `:not(\20)` chain from a suffix to a prefix, it allows pseudo elements like ::before and ::after to work.

Some have been added to `makeMeUgly.css` for testing. You won't be able to override them by adding them to the createUseStyles in the Playground App.tsx, though, because it's outside the theme. Instead, you'll have to temporarily add something like the following to the Typography root or title class itself:
`"&::after": {
      content: '""',
    },`