### PR TITLE
feat(Chip): Add to prop for React Router

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { BrowserRouter as Router } from "react-router-dom";
 import { ThemeProvider } from "@playpickup/core";
 
 export const parameters = {
@@ -8,7 +9,9 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <ThemeProvider>
-      <Story />
+      <Router>
+        <Story />
+      </Router>
     </ThemeProvider>
   ),
 ];

--- a/packages/core/src/Chip/Chip.test.tsx
+++ b/packages/core/src/Chip/Chip.test.tsx
@@ -1,4 +1,4 @@
-import React, { JSXElementConstructor } from "react";
+import React from "react";
 import { BrowserRouter as Router, Link } from "react-router-dom";
 import { fireEvent, render } from "@testing-library/react";
 

--- a/packages/core/src/Chip/Chip.test.tsx
+++ b/packages/core/src/Chip/Chip.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
+import React, { JSXElementConstructor } from "react";
+import { BrowserRouter as Router, Link } from "react-router-dom";
 import { fireEvent, render } from "@testing-library/react";
 
 import ThemeProvider from "../ThemeProvider";
@@ -50,7 +50,7 @@ test("Link element renders <a> and href correctly from 'to' prop", () => {
   const { getByText } = render(
     <ThemeProvider>
       <Router>
-        <Chip label="Click Me" to="/news" />
+        <Chip label="Click Me" element={Link} to="/news" />
       </Router>
     </ThemeProvider>
   );

--- a/packages/core/src/Chip/Chip.test.tsx
+++ b/packages/core/src/Chip/Chip.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { BrowserRouter as Router } from "react-router-dom";
 import { fireEvent, render } from "@testing-library/react";
 
 import ThemeProvider from "../ThemeProvider";
@@ -43,6 +44,17 @@ test("Element <a> and href render link correctly", () => {
   expect(getByText("Click Me").closest("a").getAttribute("href")).toBe(
     "https://www.playpickup.com"
   );
+});
+
+test("Link element renders <a> and href correctly from 'to' prop", () => {
+  const { getByText } = render(
+    <ThemeProvider>
+      <Router>
+        <Chip label="Click Me" to="/news" />
+      </Router>
+    </ThemeProvider>
+  );
+  expect(getByText("Click Me").closest("a").getAttribute("href")).toBe("/news");
 });
 
 test("Chip is disabled when prop disabled is true", () => {

--- a/packages/core/src/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/packages/core/src/Chip/__snapshots__/Chip.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Renders and matches snapshot 1`] = `
 <div>
   <button
-    class="PU--root-0-2-2 PU--isActive-0-2-8 PU--isActive-d0-0-2-9"
+    class="PU--root-0-2-3 PU--isActive-0-2-9 PU--isActive-d0-0-2-10"
     data-testid="chip"
   >
     <span>

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -114,7 +114,30 @@ const Chip: React.FC<ChipProps> = ({
   const classes = useStyles({ color, disabled });
   const Element: keyof JSX.IntrinsicElements = element ? element : "button";
 
-  const renderedChip = (
+  if (to) {
+    return (
+      <Link to={to} className={classes.link}>
+        <Element
+          data-testid="chip"
+          disabled={disabled}
+          className={classNames({
+            [classes.root]: true,
+            [classes.primary]: color && color === "primary",
+            [classes.secondary]: color && color === "secondary",
+            [classes.disabled]: disabled,
+            [classes.isActive]: isActive,
+            [className]: className,
+          })}
+          onClick={onClick}
+          style={style}
+        >
+          <span>{label}</span>
+        </Element>
+      </Link>
+    );
+  }
+
+  return (
     <Element
       data-testid="chip"
       disabled={disabled}
@@ -133,16 +156,6 @@ const Chip: React.FC<ChipProps> = ({
       <span>{label}</span>
     </Element>
   );
-
-  if (to) {
-    return (
-      <Link to={to} className={classes.link}>
-        {renderedChip}
-      </Link>
-    );
-  }
-
-  return renderedChip;
 };
 
 export default Chip;

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -1,5 +1,4 @@
 import React, { JSXElementConstructor } from "react";
-import { Link } from "react-router-dom";
 import classNames from "classnames";
 import { createUseStyles } from "react-jss";
 
@@ -112,7 +111,7 @@ const Chip: React.FC<ChipProps> = ({
   to,
 }) => {
   const classes = useStyles({ color, disabled });
-  let Element: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown> =
+  const Element: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown> =
     element ?? "button";
 
   return (

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { JSXElementConstructor } from "react";
 import { Link } from "react-router-dom";
 import classNames from "classnames";
 import { createUseStyles } from "react-jss";
@@ -112,30 +112,8 @@ const Chip: React.FC<ChipProps> = ({
   to,
 }) => {
   const classes = useStyles({ color, disabled });
-  const Element: keyof JSX.IntrinsicElements = element ? element : "button";
-
-  if (to) {
-    return (
-      <Link to={to} className={classes.link}>
-        <Element
-          data-testid="chip"
-          disabled={disabled}
-          className={classNames({
-            [classes.root]: true,
-            [classes.primary]: color && color === "primary",
-            [classes.secondary]: color && color === "secondary",
-            [classes.disabled]: disabled,
-            [classes.isActive]: isActive,
-            [className]: className,
-          })}
-          onClick={onClick}
-          style={style}
-        >
-          <span>{label}</span>
-        </Element>
-      </Link>
-    );
-  }
+  let Element: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown> =
+    element ?? "button";
 
   return (
     <Element
@@ -152,6 +130,7 @@ const Chip: React.FC<ChipProps> = ({
       onClick={onClick}
       style={style}
       href={href}
+      to={to || href}
     >
       <span>{label}</span>
     </Element>

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -129,7 +129,7 @@ const Chip: React.FC<ChipProps> = ({
       onClick={onClick}
       style={style}
       href={href}
-      to={to || href}
+      to={to}
     >
       <span>{label}</span>
     </Element>

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import classNames from "classnames";
 import { createUseStyles } from "react-jss";
 
@@ -8,6 +9,9 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
   defaultActive: {
     backgroundColor: theme.colors.white,
     outline: "none",
+  },
+  link: {
+    textDecoration: "none",
   },
   root: {
     display: "inline-flex",
@@ -105,10 +109,12 @@ const Chip: React.FC<ChipProps> = ({
   onClick,
   element,
   href,
+  to,
 }) => {
   const classes = useStyles({ color, disabled });
   const Element: keyof JSX.IntrinsicElements = element ? element : "button";
-  return (
+
+  const renderedChip = (
     <Element
       data-testid="chip"
       disabled={disabled}
@@ -127,6 +133,16 @@ const Chip: React.FC<ChipProps> = ({
       <span>{label}</span>
     </Element>
   );
+
+  if (to) {
+    return (
+      <Link to={to} className={classes.link}>
+        {renderedChip}
+      </Link>
+    );
+  }
+
+  return renderedChip;
 };
 
 export default Chip;

--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -111,7 +111,7 @@ const Chip: React.FC<ChipProps> = ({
   to,
 }) => {
   const classes = useStyles({ color, disabled });
-  const Element: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown> =
+  const Element: keyof JSX.IntrinsicElements | JSXElementConstructor<any> =
     element ?? "button";
 
   return (

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -469,7 +469,7 @@ export interface ChipProps {
   style?: React.CSSProperties;
   isActive?: boolean;
   label: string;
-  element?: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown>;
+  element?: keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
   href?: string;
   to?: string;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -470,6 +470,7 @@ export interface ChipProps {
   label: string;
   element?: keyof JSX.IntrinsicElements;
   href?: string;
+  to?: string;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -10,7 +10,6 @@ import React, {
   ReactNodeArray,
   JSXElementConstructor,
 } from "react";
-import { Link } from "react-router-dom";
 import { StyleSheet } from "jss";
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -8,7 +8,9 @@ import React, {
   SetStateAction,
   Dispatch,
   ReactNodeArray,
+  JSXElementConstructor,
 } from "react";
+import { Link } from "react-router-dom";
 import { StyleSheet } from "jss";
 
 /**
@@ -468,7 +470,7 @@ export interface ChipProps {
   style?: React.CSSProperties;
   isActive?: boolean;
   label: string;
-  element?: keyof JSX.IntrinsicElements;
+  element?: keyof JSX.IntrinsicElements | JSXElementConstructor<unknown>;
   href?: string;
   to?: string;
 }

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -229,11 +229,6 @@ const App: React.FC = () => {
   return (
     <div className={classes.playground}>
       <ThemeProvider withReset={false}>
-        <Router>
-          <div style={{ margin: 50 }}>
-            <Breadcrumbs crumbs={crumbs} />
-          </div>
-        </Router>
         <div style={{ padding: 40 }}>
           <Typography variant="title">Hello, PickUp!</Typography>
           <Typography
@@ -247,6 +242,18 @@ const App: React.FC = () => {
             Feel free to throw some components in here for testing. It's your
             lil component playground!
           </Typography>
+
+          <Router>
+            <div style={{ margin: 50 }}>
+              <Breadcrumbs crumbs={crumbs} />
+              <Chip
+                color="primary"
+                label="Chip With Router"
+                to="/news"
+                isActive
+              />
+            </div>
+          </Router>
 
           <Typography variant="title">title</Typography>
           <Typography variant="heading2">heading 2</Typography>

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -1,7 +1,7 @@
 /* To test aggressive mode, put some strong selectors in 'makeMeUgly.css' and uncomment its import below */
 
 import React, { useState, useEffect } from "react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router, Link } from "react-router-dom";
 import "./index.css";
 // import "./makeMeUgly.css";
 import { Form, Formik, Field } from "formik";
@@ -248,6 +248,7 @@ const App: React.FC = () => {
               <Breadcrumbs crumbs={crumbs} />
               <Chip
                 color="primary"
+                element={Link}
                 label="Chip With Router"
                 to="/news"
                 isActive

--- a/stories/Chip.stories.tsx
+++ b/stories/Chip.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Router from "react-router-dom";
 import { Story, Meta } from "@storybook/react";
 
 import { Chip } from "@playpickup/core";
@@ -52,9 +53,9 @@ export default {
       type: { name: "string", required: true },
     },
     to: {
-      description: "Destination path for router Link",
+      description:
+        "Allows the Chip to use React Router Link component under the hood and uses `to` value as link",
       defaultValue: null,
-      type: "text",
     },
   },
   args: {
@@ -64,6 +65,7 @@ export default {
     color: "default",
     disabled: false,
     label: "All Sports",
+    to: "",
   },
 } as Meta;
 

--- a/stories/Chip.stories.tsx
+++ b/stories/Chip.stories.tsx
@@ -51,6 +51,11 @@ export default {
       defaultValue: null,
       type: { name: "string", required: true },
     },
+    to: {
+      description: "Destination path for router Link",
+      defaultValue: null,
+      type: "text",
+    },
   },
   args: {
     isActive: false,

--- a/stories/Chip.stories.tsx
+++ b/stories/Chip.stories.tsx
@@ -52,9 +52,14 @@ export default {
       defaultValue: null,
       type: { name: "string", required: true },
     },
+    element: {
+      description:
+        "Underlying HTML element or JSX Constructor to render, default value is button",
+      defaultValue: null,
+    },
     to: {
       description:
-        "Allows the Chip to use React Router Link component under the hood and uses `to` value as link",
+        "Allows the Chip to use React Router Link component under the hood and uses `to` value as link. Element must be Link constructor",
       defaultValue: null,
     },
   },
@@ -66,6 +71,7 @@ export default {
     disabled: false,
     label: "All Sports",
     to: "",
+    element: "button",
   },
 } as Meta;
 


### PR DESCRIPTION
Adds a 'to' prop to the Chip component, which wraps the returned component in a React Router Link.

Also added the React Router as a decorator to Storybook, allowing Links in this and other components to render without creating an error.