### PR TITLE
feat(breadcrumbs): link underlines during hover

### DIFF
--- a/packages/core/src/Breadcrumbs/index.tsx
+++ b/packages/core/src/Breadcrumbs/index.tsx
@@ -21,6 +21,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     textDecoration: "none",
     "&:hover": {
       textDecoration: "underline",
+      color: theme.colors.primary.base,
     },
   },
   separator: {

--- a/packages/core/src/Breadcrumbs/index.tsx
+++ b/packages/core/src/Breadcrumbs/index.tsx
@@ -19,6 +19,9 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
   link: {
     color: theme.colors.black,
     textDecoration: "none",
+    "&:hover": {
+      textDecoration: "underline",
+    },
   },
   separator: {
     display: "inline-block",


### PR DESCRIPTION
The back links in a breadcrumbs component will underline when a mouse hovers over