### PR TITLE
fix(themeProvider): Make container plugin work with React.StrictMode

### DIFF
--- a/packages/core/src/ThemeProvider/containerPlugin.ts
+++ b/packages/core/src/ThemeProvider/containerPlugin.ts
@@ -1,11 +1,11 @@
-/* 
-*  Adds container params to all selectors
-*  Example: 'h1' becomes 'body #PickUpUI h1'
-*/
+/*
+ *  Adds container params to all selectors
+ *  Example: 'h1' becomes 'body #PickUpUI h1'
+ */
 
 import { Plugin } from "jss";
 
-export function containUI(container?: string ): Plugin {
+export function containUI(container?: string): Plugin {
   const prefix = container ? container : "body #PickUpUI ";
 
   // 'rule' is left untyped because the Rule import from jss is not recognizing all child properties
@@ -14,12 +14,11 @@ export function containUI(container?: string ): Plugin {
     if (
       rule.type !== "style" ||
       (parent && parent.type === "keyframes") ||
-      rule.key.includes(prefix)
+      rule.selectorText.includes(prefix)
     )
       return;
 
     rule.selectorText = prefix + rule.selectorText;
-    
   }
   return { onProcessRule };
 }


### PR DESCRIPTION
Fixes an issue where none of the internal styles would render when an app is wrapped in `React.StrictMode`.