### PR TITLE
fix(themeProvider): Contain comma-separated selectors

### DIFF
--- a/packages/core/src/ThemeProvider/containerPlugin.ts
+++ b/packages/core/src/ThemeProvider/containerPlugin.ts
@@ -18,7 +18,15 @@ export function containUI(container?: string): Plugin {
     )
       return;
 
-    rule.selectorText = prefix + rule.selectorText;
+    if (rule.selectorText.includes(",")) {
+      const allSelectors = rule.selectorText.split(",");
+      const transformedSelectors = allSelectors.map((selector: string) =>
+        selector.includes(prefix) ? selector : prefix + selector
+      );
+      rule.selectorText = transformedSelectors.join(",");
+    } else {
+      rule.selectorText = prefix + rule.selectorText;
+    }
   }
   return { onProcessRule };
 }

--- a/playground/src/App/makeMeUgly.css
+++ b/playground/src/App/makeMeUgly.css
@@ -1,4 +1,4 @@
-.Playground {
+body {
   background-color: darkgoldenrod;
 }
 


### PR DESCRIPTION
Fixes a bug where, if multiple selectors are in a comma-separated list in a rule (`body, html, h1`), the container was only applied to the first element of the list. The side effect was that many resets were applied globally instead of just within the container.

![image](https://user-images.githubusercontent.com/54251395/143945497-ca19b1ba-a269-433e-a0db-eebd32b9f074.png)
