### PR TITLE
fix(themeProvider): Use withReset to trigger global or local resets

### DIFF
--- a/packages/core/src/ThemeProvider/containerPlugin.ts
+++ b/packages/core/src/ThemeProvider/containerPlugin.ts
@@ -5,7 +5,7 @@
 
 import { Plugin } from "jss";
 
-export function containUI(container?: string): Plugin {
+export function containUI(withReset: boolean, container?: string): Plugin {
   const prefix = container ? container : "body #PickUpUI ";
 
   // 'rule' is left untyped because the Rule import from jss is not recognizing all child properties
@@ -13,8 +13,9 @@ export function containUI(container?: string): Plugin {
     const parent = rule.options.parent;
     if (
       rule.type !== "style" ||
+      rule.selectorText.includes(prefix) ||
       (parent && parent.type === "keyframes") ||
-      rule.selectorText.includes(prefix)
+      (withReset && parent && parent.key === "@global")
     )
       return;
 

--- a/packages/core/src/ThemeProvider/containerPlugin.ts
+++ b/packages/core/src/ThemeProvider/containerPlugin.ts
@@ -13,7 +13,7 @@ export function containUI(withReset: boolean, container?: string): Plugin {
     const parent = rule.options.parent;
     if (
       rule.type !== "style" ||
-      rule.selectorText.includes(prefix) ||
+      rule.selectorText?.includes(prefix) ||
       (parent && parent.type === "keyframes") ||
       (withReset && parent && parent.key === "@global")
     )

--- a/packages/core/src/ThemeProvider/index.tsx
+++ b/packages/core/src/ThemeProvider/index.tsx
@@ -14,13 +14,13 @@ const ThemeProvider: React.FC<ThemeProviderProps> = ({
   theme,
   ...rest
 }) => {
-  jss.use(containUI());
+  jss.use(containUI(withReset));
   const mergedTheme = theme ? merge(defaultTheme, theme) : defaultTheme;
   return (
     <div id="PickUpUI">
       <JssProvider jss={jss} classNamePrefix="PU--">
         <JSSThemeProvider theme={mergedTheme} {...rest}>
-          {withReset ? <GlobalsAndReset>{children}</GlobalsAndReset> : children}
+          <GlobalsAndReset>{children}</GlobalsAndReset>
         </JSSThemeProvider>
       </JssProvider>
     </div>

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -229,7 +229,7 @@ const App: React.FC = () => {
   return (
     <ThemeProvider>
       <Router>
-        <div>
+        <div className="Playground">
           <Hero
             title="The State of Sports Betting"
             description="Mobile and online sports betting is now legal and available in 15 states in the United States. It’s been three years since the Supreme Court struck down the federal ban on sports betting, allowing states to legalize it if they wish."


### PR DESCRIPTION
One approach to the reset bug. I slightly changed the behavior of `withReset` so that when it's true, it triggers the resets globally, and when false, it triggers them at the local "container" level.