### PR TITLE
fix(heroimg): fix img crop for safari broswer with hero

### DIFF
--- a/packages/core/src/Hero/index.tsx
+++ b/packages/core/src/Hero/index.tsx
@@ -65,7 +65,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
   image: {
     display: "block",
     maxWidth: "100%",
-    height: "100%",
+    height: "auto",
     objectFit: "cover",
   },
   eyebrow: {

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -233,7 +233,7 @@ const App: React.FC = () => {
           <Hero
             title="The State of Sports Betting"
             description="Mobile and online sports betting is now legal and available in 15 states in the United States. It’s been three years since the Supreme Court struck down the federal ban on sports betting, allowing states to legalize it if they wish."
-            image_src="https://www.playpickup.com/3a6ae08caa07d98bdee0.svg"
+            image_src="https://images.ctfassets.net/vr34jcb0tstv/6v9VCB5kU8MB1F5DOojcfW/ac4b49231aaee3ef086045efb23c5935/fanatics_white.png"
             image_alt="pickup-logo"
             eyebrow={{ name: "Fanatics", description: "$30 value" }} // comment out to see non-eyebrow formatting
             crumbs={crumbs}


### PR DESCRIPTION
there was a img crop bug in hero component that seemed to be unique to a safari browser.
https://app.zenhub.com/workspaces/pickup-5ee6cbe39ef1ca001fefe69b/issues/playpickup/web/228

fixed img:
![image](https://user-images.githubusercontent.com/55102812/145235856-7018be3d-8e0b-47c7-a7cd-c5f4a57be934.png)
