### PR TITLE
test(feedCard): Enhance FeedCard tests, closes #258

### DIFF
--- a/packages/core/src/FeedCard/FeedCard.test.tsx
+++ b/packages/core/src/FeedCard/FeedCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 
 import ThemeProvider from "../ThemeProvider";
 import FeedCard from "./index";
@@ -38,4 +38,67 @@ test("Renders and matches snapshot", () => {
     </ThemeProvider>
   );
   expect(container).toMatchSnapshot();
+});
+
+test("Passes and renders props", () => {
+  const { getByTestId, getByRole, getByText } = render(
+    <ThemeProvider>
+      <FeedCard
+        publisherIcon="https://playpickup.s3.us-east-2.amazonaws.com/away-team/kasper/homebase/prize-images/crossnet-play.jpg"
+        publisherName="Prime Time Sports"
+        publishedAt="23m"
+        title="Chiefs vs. Ravens Who wins?"
+        image="https://static.clubs.nfl.com/image/private/t_editorial_landscape_12_desktop/ravens/qhsyhehrwlw6he1nfmq0"
+        pickCount={2}
+        timeLeft={new Date()}
+        picks={[
+          { label: "Ravens", value: "Ravens" },
+          { label: "Chiefs", value: "Chiefs" },
+        ]}
+        expanded={false}
+      />
+    </ThemeProvider>
+  );
+  // image
+  expect(getByTestId("featuredImage").getAttribute("style")).toContain(
+    "background-image: url(https://static.clubs.nfl.com/image/private/t_editorial_landscape_12_desktop/ravens/qhsyhehrwlw6he1nfmq0)"
+  );
+  // publisherIcon
+  expect(getByRole("img").getAttribute("src")).toEqual(
+    "https://playpickup.s3.us-east-2.amazonaws.com/away-team/kasper/homebase/prize-images/crossnet-play.jpg"
+  );
+  // publishedAt
+  expect(getByText("23m")).toBeTruthy();
+  // title
+  expect(getByText("Chiefs vs. Ravens Who wins?")).toBeTruthy();
+  // pickCount
+  expect(getByText("Picked")).toBeTruthy();
+  // timeLeft
+  expect(getByText("CLOSED")).toBeTruthy();
+  // picks
+  expect(getByRole("button", { name: /Chiefs/i })).toBeTruthy();
+});
+
+test("Shows remaining time when time is left", async () => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const { getByText } = render(
+    <ThemeProvider>
+      <FeedCard
+        publisherIcon="https://playpickup.s3.us-east-2.amazonaws.com/away-team/kasper/homebase/prize-images/crossnet-play.jpg"
+        publisherName="Prime Time Sports"
+        publishedAt="23m"
+        title="Chiefs vs. Ravens Who wins?"
+        image="https://static.clubs.nfl.com/image/private/t_editorial_landscape_12_desktop/ravens/qhsyhehrwlw6he1nfmq0"
+        pickCount={2}
+        timeLeft={tomorrow}
+        picks={[
+          { label: "Ravens", value: "Ravens" },
+          { label: "Chiefs", value: "Chiefs" },
+        ]}
+        expanded={false}
+      />
+    </ThemeProvider>
+  );
+  await waitFor(() => expect(getByText("23h 59m")).toBeTruthy());
 });

--- a/packages/core/src/FeedCard/__snapshots__/FeedCard.test.tsx.snap
+++ b/packages/core/src/FeedCard/__snapshots__/FeedCard.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Renders and matches snapshot 1`] = `
           title="Chiefs vs. Ravens Who wins?"
         >
           <div
+            data-testid="featuredImage"
             style="background-image: url(https://static.clubs.nfl.com/image/private/t_editorial_landscape_12_desktop/ravens/qhsyhehrwlw6he1nfmq0);"
           />
         </a>
@@ -135,6 +136,7 @@ exports[`Renders and matches snapshot 1`] = `
           title="Chiefs vs. Ravens Who wins?"
         >
           <div
+            data-testid="featuredImage"
             style="background-image: url(https://static.clubs.nfl.com/image/private/t_editorial_landscape_12_desktop/ravens/qhsyhehrwlw6he1nfmq0);"
           />
         </a>

--- a/packages/core/src/FeedCard/index.tsx
+++ b/packages/core/src/FeedCard/index.tsx
@@ -176,7 +176,7 @@ const FeedCard: React.FC<FeedCardProps> = ({
           }
           title={title}
         >
-          <div style={renderFeaturedImage(image)} />
+          <div style={renderFeaturedImage(image)} data-testid="featuredImage" />
         </a>
       </div>
 


### PR DESCRIPTION
This test has a number of occurrences of the warning `[JSS] Rule is not linked.` This is a known issue with one of the default jss plugins in `react-jss` which handles items like media queries, and has no immediate fix.