### PR TITLE
fix(breadcrumbs): adjust styling for breadcrumbs to wrap best it can

### DIFF
--- a/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -10,22 +10,26 @@ exports[`Renders and matches snapshot 1`] = `
     >
       <ul
         aria-label="breadcrumbs"
-        class="PU--list-0-2-2"
+        class="PU--uList-0-2-2"
       >
-        <li>
+        <li
+          class="PU--nameList-0-2-3"
+        >
           <a
-            class="PU--link-0-2-3"
+            class="PU--link-0-2-5"
             href="/sports-betting"
           >
             Sports Betting
           </a>
           <span
-            class="PU--separator-0-2-4"
+            class="PU--separator-0-2-6"
           >
             /
           </span>
         </li>
-        <li>
+        <li
+          class="PU--pathList-0-2-4"
+        >
           Arizona Sports Betting
         </li>
       </ul>

--- a/packages/core/src/Breadcrumbs/index.tsx
+++ b/packages/core/src/Breadcrumbs/index.tsx
@@ -10,12 +10,19 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     lineHeight: `${theme.spacing.base * 5}px`,
     color: theme.colors.black,
   },
-  list: {
-    display: "flex",
-    alignItems: "center",
+  uList: {
+    display: "inline-flex",
     listStyle: "none",
+    flexWrap: "flex",
     padding: 0,
     margin: 0,
+  },
+  nameList: {
+    display: "inline-flex",
+    flexWrap: "no wrap",
+  },
+  pathList: {
+    textAlign: "left",
   },
   link: {
     color: theme.colors.black,
@@ -39,11 +46,15 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   const classes = useStyles();
   const mappedCrumbs = crumbs.map(({ path, name }, index: number) => {
     if (index === crumbs.length - 1) {
-      return <li key={name}>{name}</li>;
+      return (
+        <li key={name} className={classes.pathList}>
+          {name}
+        </li>
+      );
     }
 
     return (
-      <li key={name}>
+      <li key={name} className={classes.nameList}>
         <Link className={classes.link} to={path}>
           {name}
         </Link>
@@ -59,7 +70,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
         [classes.root]: true,
       })}
     >
-      <ul className={classes.list} aria-label="breadcrumbs">
+      <ul className={classes.uList} aria-label="breadcrumbs">
         {mappedCrumbs}
       </ul>
     </nav>

--- a/packages/core/src/Hero/index.tsx
+++ b/packages/core/src/Hero/index.tsx
@@ -97,6 +97,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     marginTop: theme.spacing.base * 2,
   },
   breadcrumbs: {
+    textAlign: "left",
     marginBottom: theme.spacing.base * 4,
     [theme.mediaQuery(theme.breakpoints.small)]: {
       marginBottom: 0,

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -208,12 +208,12 @@ const Picks = [
 
 const crumbs = [
   {
-    name: "Sports Betting",
+    name: "marketplace",
     path: "/sports-betting",
   },
   {
-    name: "Arizona Sports Betting",
-    path: "/arizona-sports-betting",
+    name: "$200 off $400 TRX Suspension Trainer Bundle & Training Club",
+    path: "/$200 off $400 TRX Suspension Trainer Bundle & Training Club",
   },
 ];
 
@@ -233,7 +233,7 @@ const App: React.FC = () => {
           <Hero
             title="The State of Sports Betting"
             description="Mobile and online sports betting is now legal and available in 15 states in the United States. It’s been three years since the Supreme Court struck down the federal ban on sports betting, allowing states to legalize it if they wish."
-            image_src="https://images.ctfassets.net/vr34jcb0tstv/6v9VCB5kU8MB1F5DOojcfW/ac4b49231aaee3ef086045efb23c5935/fanatics_white.png"
+            image_src="https://playpickup.s3.us-east-2.amazonaws.com/away-team/kasper/homebase/prize-images/trx-setup-logo.png"
             image_alt="pickup-logo"
             eyebrow={{ name: "Fanatics", description: "$30 value" }} // comment out to see non-eyebrow formatting
             crumbs={crumbs}


### PR DESCRIPTION
breadcrumbs was not wrapping to the best of its ability.  This PR adjusts styling in hero/breadcumbs to make it wrap best it can.

https://app.zenhub.com/workspaces/pickup-5ee6cbe39ef1ca001fefe69b/issues/playpickup/pickup-ui/252

new new
![image](https://user-images.githubusercontent.com/55102812/146039936-cb58a716-03e2-4ae8-a7fa-3bd67f166c9f.png)

![image](https://user-images.githubusercontent.com/55102812/146040221-120feee7-630c-4ae3-9c8f-b809e232b18c.png)
