### PR TITLE
fix(theme): Add medium grey to theme

### DIFF
--- a/packages/core/src/ThemeProvider/defaultTheme.ts
+++ b/packages/core/src/ThemeProvider/defaultTheme.ts
@@ -35,6 +35,7 @@ const grey: GreyMap = {
   lightBase: "#DDDDDD",
   base: "#9D9D9E",
   dark: "#615E66",
+  medium: "#DFDAE6",
 };
 
 const red: RedMap = {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -58,6 +58,7 @@ export interface GreyMap {
   lightBase: string;
   base: string;
   dark: string;
+  medium: string;
 }
 
 export interface RedMap {


### PR DESCRIPTION
We currently have an unthemed grey in use in several places in the Picker and Web, `#DFDAE6`. This adds that grey to our theme as `medium` and allows it to be themed by other publishers.