### PR TITLE
fix(defaultTheme): allow partial colors and typography passed into de…

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -38,7 +38,7 @@ export type JssStyleSheet = StyleSheet & {
 export interface ThemeProviderProps {
   children: any;
   withReset?: boolean;
-  theme?: DefaultTheme;
+  theme?: Partial<DefaultTheme>;
 }
 
 export interface PurpleMap {
@@ -157,11 +157,11 @@ export type DefaultTheme = {
   borderRadius: number;
   breakpoints: Breakpoints;
   mediaQuery: MediaQuery;
-  colors: DefaultThemeColors;
+  colors: Partial<DefaultThemeColors>;
   gradients: DefaultGradients;
   shadows: DefaultShadows;
   spacing: DefaultSpacing;
-  typography: DefaultTypography;
+  typography: Partial<DefaultTypography>;
   zIndex: DefaultZIndex;
 };
 

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -33,6 +33,7 @@ import {
   createUseStyles,
   CheckBox,
   Breadcrumbs,
+  DefaultTheme,
 } from "@playpickup/core";
 import { Create, Countdown, Pick } from "@playpickup/icons";
 
@@ -216,6 +217,31 @@ const crumbs = [
     path: "/$200 off $400 TRX Suspension Trainer Bundle & Training Club",
   },
 ];
+const red = {
+  light: "#FF1244",
+  base: "#FF1244",
+};
+const grey = {
+  light: "#FF1244",
+  lightBase: "#FF1244",
+  base: "#FF1244",
+  dark: "#FF1244",
+};
+
+const publisherTheme: Partial<DefaultTheme> = {
+  colors: {
+    // primary: { ...grey },
+    // secondary: { ...grey },
+    // green: red,
+    // purple: grey,
+    // grey,
+    // red,
+    black: "#FF1244",
+    // white: "#FFF",
+    // success: red.base,
+    // error: red.base,
+  },
+};
 
 const App: React.FC = () => {
   const [twoStep, setTwoStep] = useState<boolean>(false);
@@ -227,7 +253,7 @@ const App: React.FC = () => {
   });
   // Outer div with className "Playground" is targeted by MakeMeUgly
   return (
-    <ThemeProvider>
+    <ThemeProvider theme={publisherTheme}>
       <Router>
         <div className="Playground">
           <Hero
@@ -239,6 +265,14 @@ const App: React.FC = () => {
             crumbs={crumbs}
             chip="500 Points"
           />
+          <Typography variant="body">
+            we are here today to test partial theme override
+          </Typography>
+          <PickerButton
+            displayText="testPickerButton"
+            onClick={() => console.log("test")}
+            result={1}
+          ></PickerButton>
         </div>
       </Router>
     </ThemeProvider>


### PR DESCRIPTION
allow themeProvider to accept partial defaultThemes and allow defaultThemes to have partial color and typographys defined and passed.

This will work with the new publisher theme overrides on prop picker

tested in playground by changing only black fonts to red

![image](https://user-images.githubusercontent.com/55102812/147972808-a6945c41-4576-4b8e-8206-56cc2937a40e.png)
