### PR TITLE
fix(icons): set maxwidth to match size

### DIFF
--- a/packages/core/src/Icon/index.tsx
+++ b/packages/core/src/Icon/index.tsx
@@ -9,6 +9,7 @@ const useStyles = createUseStyles({
   root: {
     position: "relative",
     width: (props) => props.size,
+    maxWidth: (props) => props.size,
     height: "auto",
     "& > svg": {
       display: "block",


### PR DESCRIPTION
I can't replicate the issue so this is hard to test, but setting a `maxWidth` to match the `width` (set by the size prop) should prevent  icons from blowing up on the picker like we're seeing in the game:

![image](https://user-images.githubusercontent.com/49823725/151255458-c3a785a0-405b-4690-90e6-db300becc7b6.png)
