### PR TITLE
fix(nestedInput): Revert resets, add manual style overrides to phone button, ENG-67

### DIFF
--- a/packages/core/src/NestedInput/__snapshots__/NestedInput.test.tsx.snap
+++ b/packages/core/src/NestedInput/__snapshots__/NestedInput.test.tsx.snap
@@ -62,7 +62,7 @@ body #PickUpUI .j3 {
 
 body #PickUpUI .j4 {
   color: #615E66;
-  padding: 0 4px;
+  padding: 0 8px;
   position: relative;
   font-size: 15px;
   font-family: 'Inter', Helvetica, sans-serif;
@@ -85,8 +85,10 @@ body #PickUpUI .j6 {
 }
 
 body #PickUpUI .j9 {
+  margin: 0;
   padding: 0 8px;
   font-size: 14px;
+  font-weight: normal;
 }
 
 <div>
@@ -207,8 +209,10 @@ body #PickUpUI .j4 {
 }
 
 body #PickUpUI .j7 {
+  margin: 0;
   padding: 0 8px;
   font-size: 14px;
+  font-weight: normal;
 }
 
 <div>

--- a/packages/core/src/NestedInput/index.tsx
+++ b/packages/core/src/NestedInput/index.tsx
@@ -25,7 +25,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     width: "100%",
     maxWidth: 360,
     height: (props) => (props.usePhoneNumber ? 60 : 56),
-    padding: "0 6px",
+    padding: [0, theme.spacing.base * 1.5],
   },
   inputContainer: {
     flex: "1 1 auto",
@@ -66,7 +66,7 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     lineHeight: "22px",
     fontFamily: theme.typography.fontFamilies.body,
     color: theme.colors.grey.dark,
-    padding: "0 4px",
+    padding: [0, theme.spacing.base * 2],
   },
   phoneLabel: {
     fontSize: 11,
@@ -80,7 +80,9 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
   },
   phoneButtonSmall: {
     fontSize: 14,
-    padding: "0 8px",
+    padding: [0, theme.spacing.base * 2],
+    margin: 0,
+    fontWeight: "normal",
   },
 }));
 

--- a/packages/core/src/ThemeProvider/GlobalsAndReset.tsx
+++ b/packages/core/src/ThemeProvider/GlobalsAndReset.tsx
@@ -58,7 +58,7 @@ const GlobalsAndReset = injectSheet((theme: DefaultTheme) => ({
     },
     /* Reset `button` to nothing */
     /* https://gist.github.com/chrisheninger/a860f87ef4e529b2df606768b97665a8 */
-    'button, input[type="button"], input[type="submit"], input[type="reset"]': {
+    button: {
       all: "initial",
       display: "inline-block",
       "-webkit-appearance": "none",

--- a/playground/src/App/index.tsx
+++ b/playground/src/App/index.tsx
@@ -251,7 +251,7 @@ const App: React.FC = () => {
   // Outer div with className "Playground" is targeted by MakeMeUgly
   return (
     <div className="Playground">
-      <ThemeProvider theme={publisherTheme}>
+      <ThemeProvider theme={publisherTheme} withReset={false}>
         <Router>
           <div style={{ width: "90%" }}>
             <Formik

--- a/playground/src/App/makeMeUgly.css
+++ b/playground/src/App/makeMeUgly.css
@@ -20,5 +20,16 @@ button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
+  background-color: #000;
   margin: 0 auto 20px;
+  height: 45px;
+  display: block;
+  border: 0;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 10px 30px 11px;
+  text-transform: uppercase;
+  vertical-align: bottom;
 }


### PR DESCRIPTION
The previous fix, when paired with `withReset={false}`, is _too_ specific. The reset carries through to child elements, and effectively wipes out the button.

Reverted the reset fix and added stylings directly to the button element that is overridden by Nascar's styles, with the intention of revisiting resets to find a better long-term solution.