### PR TITLE
fix(nestedinput): fix issue where css overrides background color,eng-435

### DIFF
--- a/packages/core/src/NestedInput/__snapshots__/NestedInput.test.tsx.snap
+++ b/packages/core/src/NestedInput/__snapshots__/NestedInput.test.tsx.snap
@@ -82,6 +82,7 @@ body #PickUpUI .j5 {
   appearance: none;
   font-family: 'Inter', Helvetica, sans-serif;
   letter-spacing: 0.1px;
+  background-color: #FFF;
 }
 
 body #PickUpUI .j6 {
@@ -238,6 +239,7 @@ body #PickUpUI .j3 {
   appearance: none;
   font-family: 'Inter', Helvetica, sans-serif;
   letter-spacing: 0.1px;
+  background-color: #FFF;
 }
 
 body #PickUpUI .j4 {
@@ -383,6 +385,7 @@ body #PickUpUI .j3 {
   appearance: none;
   font-family: 'Inter', Helvetica, sans-serif;
   letter-spacing: 0.1px;
+  background-color: #FFF;
 }
 
 body #PickUpUI .j4 {

--- a/packages/core/src/NestedInput/index.tsx
+++ b/packages/core/src/NestedInput/index.tsx
@@ -43,6 +43,8 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
     color: theme.colors.grey.dark,
     appearance: "none",
     border: "none",
+    backgroundColor: theme.colors.white,
+
     "&:focus": {
       border: "none",
       outline: "none",

--- a/playground/src/App/makeMeUgly.css
+++ b/playground/src/App/makeMeUgly.css
@@ -2,6 +2,10 @@ body {
   background-color: darkgoldenrod;
 }
 
+input {
+  background-color: #000;
+}
+
 .Playground button:not(:hover):not(:active):not(.has-background) {
   background-color: #000;
 }


### PR DESCRIPTION
nascars styles are overriding ours
https://www.nascar.com/fantasy
![image](https://user-images.githubusercontent.com/55102812/173621509-546e9a9e-e174-4c75-a35a-c4c2c8eccf3f.png)

![image](https://user-images.githubusercontent.com/55102812/173620525-9f0aab1f-c29f-41b0-b274-566e06367d98.png)

recreation in playground
![image](https://user-images.githubusercontent.com/55102812/173621007-f305e302-4713-40f1-a2b0-5a17779b6789.png)


I found i can fix this in two places. I can either define a background color in the input class style of NestedInput or i can define a input styling for our GlobalsAndRest(css reset).  For now I just put the fix in NestedInput specifically, but if we want a global css fix I can change to that.